### PR TITLE
Switch backend docs from MongoDB to MySQL

### DIFF
--- a/CoderStew_PRD.md
+++ b/CoderStew_PRD.md
@@ -103,7 +103,7 @@ _Last updated: 2025-07-13_
 - **Front‑end:** Vue 3 + Ionic, Vite build, Pinia store.  
 - **Back‑end:** PHP 8.3 / Laravel 11 API with Sanctum & Horizon queues.  
 - **CMS:** **GlitchTip** (Docker).  
-- **Database:** MongoDB 6 replica set (Docker).  
+- **Database:** MySQL 8.0 (Docker).  
 - **Newsletter:** Self‑hosted **Listmonk**; SMTP via Microsoft 365; sending domain `mail.coderstew.com`.  
 - **Hosting:** Unraid server, Docker swarm behind Nginx reverse‑proxy (Let’s Encrypt SSL).  
 - **Auth:** Email+password, optional OAuth (Google, GitHub).  

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A modern, high-performance website built with Laravel 11 and Vue.js 3, featuring
 - **RESTful API**: Comprehensive API endpoints
 - **Admin Panel**: Backpack CRUD for content management
 - **Authentication**: Laravel Sanctum for API security
-- **Database**: MongoDB with Laravel MongoDB package
+- **Database**: MySQL 8.0
 - **Queue Management**: Laravel Horizon for background jobs
 - **Error Monitoring**: GlitchTip integration
 - **Performance**: Redis caching, optimized queries
@@ -29,7 +29,7 @@ A modern, high-performance website built with Laravel 11 and Vue.js 3, featuring
 ### Infrastructure
 - **Containerized**: Docker Compose setup
 - **Reverse Proxy**: Nginx with performance optimizations
-- **Database**: MongoDB for flexible data storage
+- **Database**: MySQL for relational data storage
 - **Cache**: Redis for session and application caching
 - **Monitoring**: GlitchTip for error tracking
 - **Newsletter**: Listmonk for email campaigns
@@ -49,7 +49,7 @@ A modern, high-performance website built with Laravel 11 and Vue.js 3, featuring
 ### Backend
 - **Laravel 11** - PHP web framework
 - **PHP 8.3** - Latest PHP version
-- **MongoDB** - NoSQL database
+- **MySQL** - Relational database
 - **Redis** - In-memory data store
 - **Backpack CRUD** - Admin panel
 - **Laravel Sanctum** - API authentication
@@ -256,7 +256,7 @@ or Compose Manager UI.
    paths if desired. Typical mappings on Unraid are:
    - `/mnt/user/appdata/CoderStew/backend` → `/var/www/html`
    - `/mnt/user/appdata/CoderStew/frontend` → `/app`
-   - `/mnt/user/appdata/CoderStew/mongodb` → `/data/db`
+   - `/mnt/user/appdata/CoderStew/mysql` → `/var/lib/mysql`
    - `/mnt/user/appdata/CoderStew/redis` → `/data`
 3. **Configure environment variables** for the `api` and `frontend` services
    (e.g., `APP_KEY` and `VITE_API_URL`) through the Unraid UI.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -18,9 +18,6 @@ RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 # Install PHP extensions
 RUN docker-php-ext-install pdo pdo_mysql mbstring exif pcntl bcmath gd
 
-# Install MongoDB extension
-RUN pecl install mongodb && docker-php-ext-enable mongodb
-
 # Install Redis extension
 RUN pecl install redis && docker-php-ext-enable redis
 

--- a/backend/app/Http/Controllers/Admin/ProjectCrudController.php
+++ b/backend/app/Http/Controllers/Admin/ProjectCrudController.php
@@ -108,7 +108,6 @@ class ProjectCrudController extends CrudController
             'JavaScript' => 'JavaScript',
             'TypeScript' => 'TypeScript',
             'Python' => 'Python',
-            'MongoDB' => 'MongoDB',
             'MySQL' => 'MySQL',
             'PostgreSQL' => 'PostgreSQL',
             'Docker' => 'Docker',

--- a/backend/config/app.php
+++ b/backend/config/app.php
@@ -159,7 +159,6 @@ return [
          */
         Laravel\Sanctum\SanctumServiceProvider::class,
         Laravel\Horizon\HorizonServiceProvider::class,
-        Jenssegers\Mongodb\MongodbServiceProvider::class,
 
         /*
          * Application Service Providers...


### PR DESCRIPTION
## Summary
- remove MongoDB extension from backend Dockerfile
- drop MongoDB service provider
- delete MongoDB from project technology options
- update documentation to describe MySQL instead of MongoDB

## Testing
- `php artisan --version` *(fails: vendor directory missing)*
- `composer install --no-interaction --no-progress` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_6879a2ae2e088333b7e8c77c2426d55a