### PR TITLE
Fix Docker build by removing missing vite plugin

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,7 +21,6 @@
   "devDependencies": {
     "@types/node": "^20.0.0",
     "typescript": "^5.0.0",
-    "vite-plugin-vue-type-imports": "^1.0.0",
     "@vue/eslint-config-typescript": "^11.0.0",
     "eslint": "^8.0.0",
     "eslint-plugin-vue": "^9.0.0"


### PR DESCRIPTION
## Summary
- remove `vite-plugin-vue-type-imports` from frontend devDependencies

## Testing
- `npm install --no-audit --progress=false` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@ionic%2fvue)*
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_687aa01fa1ac8333a283d5c85542416b